### PR TITLE
feat/Add_webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,20 @@
+const path = require('path')
+module.exports = {
+  entry: path.join(__dirname, 'src/index.js'),
+  output: {
+    path.join(__dirname, 'public')
+    filename: 'bundle.js'
+  },
+  devtool: 'inline-source-map',
+  modules: {
+    rules: [
+      {
+        test: /.js$/,
+        loader: 'babel-loader'
+        options: {
+          presets: ['es2015','react']
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Overview
コンパイルを行う設定が記載された`webpack.config.js`を作成しました。

## webpack.config.js

```webpack.config.js
const path = require('path')
module.exports = {
  entry: path.join(__dirname, 'src/index.js'),
  //__dirname = ここではrootディレクトリ
  output: {
    path.join(__dirname, 'public')
    filename: 'bundle.js'
  },
  devtool: 'inline-source-map',
  modules: {
    rules: [
      {
        test: /.js$/,
        loader: 'babel-loader'
        options: {
          presets: ['es2015','react']
        }
      }
    ]
  }
}
```